### PR TITLE
Fix inter-registry conflicts

### DIFF
--- a/src/main/java/net/citizensnpcs/api/npc/AbstractNPC.java
+++ b/src/main/java/net/citizensnpcs/api/npc/AbstractNPC.java
@@ -171,7 +171,7 @@ public abstract class AbstractNPC implements NPC {
         } else if (!name.equals(other.name)) {
             return false;
         }
-        return true;
+        return registry.equals(other.registry);
     }
 
     @Override


### PR DESCRIPTION
Fixes NPC's with identical name and ID from different registries cause conflicts.

I've been having issues with NPC's that are spawned in unloaded chunks not spawning after the chunk is loaded. I tracked the issue down to having NPC's from different registries with identical id and name causing problems in `net.citizensnpcs.EventListen`, specifically with the `toRespawn` ArrayListMultimap.