### PR TITLE
Fix cross-world teleport

### DIFF
--- a/src/main/java/net/citizensnpcs/api/ai/TeleportStuckAction.java
+++ b/src/main/java/net/citizensnpcs/api/ai/TeleportStuckAction.java
@@ -23,8 +23,10 @@ public class TeleportStuckAction implements StuckAction {
         if (!npc.isSpawned())
             return false;
         Location base = navigator.getTargetAsLocation();
-        if (npc.getEntity().getLocation().distanceSquared(base) <= RANGE)
+        if (npc.getEntity().getWorld().equals(base.getWorld())
+                && npc.getEntity().getLocation().distanceSquared(base) <= RANGE) {
             return true;
+        }
         Block block = base.getBlock();
         int iterations = 0;
         while (!canStand(block)) {


### PR DESCRIPTION
TeleportStuckAction crashes if the NPC is in the wrong world. This corrects that to respond with a teleportation as one would expect.