### PR TITLE
( Patch for Citizens2#1455 ) Add NPCDataStore#reloadFromSource()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,5 +101,5 @@
                 </configuration>
             </plugin>
 		</plugins>
-	</build> 
+	</build>
 </project>

--- a/src/main/java/net/citizensnpcs/api/npc/MemoryNPCDataStore.java
+++ b/src/main/java/net/citizensnpcs/api/npc/MemoryNPCDataStore.java
@@ -31,4 +31,8 @@ public class MemoryNPCDataStore implements NPCDataStore {
     @Override
     public void storeAll(NPCRegistry registry) {
     }
+
+    @Override
+    public void reloadFromSource() {
+    }
 }

--- a/src/main/java/net/citizensnpcs/api/npc/NPCDataStore.java
+++ b/src/main/java/net/citizensnpcs/api/npc/NPCDataStore.java
@@ -3,7 +3,7 @@ package net.citizensnpcs.api.npc;
 public interface NPCDataStore {
     /**
      * Clears all data about the given {@link NPC} from storage. Called when the NPC is removed.
-     * 
+     *
      * @param npc
      *            The NPC to clear data from
      */
@@ -18,7 +18,7 @@ public interface NPCDataStore {
 
     /**
      * Loads NPCs from disk into the given {@link NPCRegistry}. The registry should be cleared before this is called.
-     * 
+     *
      * @param registry
      *            The NPCRegistry to load NPCs into
      */
@@ -36,7 +36,7 @@ public interface NPCDataStore {
 
     /**
      * Stores the given {@link NPC} into memory or to a disk representation.
-     * 
+     *
      * @param npc
      *            The NPC to store
      */
@@ -44,9 +44,14 @@ public interface NPCDataStore {
 
     /**
      * Stores all {@link NPC}s in the given {@link NPCRegistry} to disk.
-     * 
+     *
      * @param registry
      *            The registry to store NPCs from
      */
     void storeAll(NPCRegistry registry);
+
+    /**
+     * Reloads the data store from source (such as a file on disk).
+     */
+    void reloadFromSource();
 }

--- a/src/main/java/net/citizensnpcs/api/npc/SimpleNPCDataStore.java
+++ b/src/main/java/net/citizensnpcs/api/npc/SimpleNPCDataStore.java
@@ -118,6 +118,11 @@ public class SimpleNPCDataStore implements NPCDataStore {
         return type;
     }
 
+    @Override
+    public void reloadFromSource() {
+        root.load();
+    }
+
     private static final String LOAD_NAME_NOT_FOUND = "citizens.notifications.npc-name-not-found";
     private static final String LOAD_UNKNOWN_NPC_TYPE = "citizens.notifications.unknown-npc-type";
 }


### PR DESCRIPTION
It's very helpful to be able to reload the NPCDataStore from its source Storage object.
See also https://github.com/CitizensDev/Citizens2/pull/1456