### PR TITLE
Fix issues with maven information

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Include CitizensAPI in your pom.xml like this (set the artifactId to citizens if
     <groupId>net.citizensnpcs</groupId>
     <artifactId>citizensapi</artifactId>
     <version>CITIZENS_VERSION</version>
-    <scope>scope</scope>
+    <scope>provided</scope>
 </dependency>
 ```
 
-The correct CITIZENS_VERSION to use can depend on your minecraft version. A list can be found here http://repo.citizensnpcs.co/net/citizensnpcs/citizensapi/ - or you can use the version listed in the Citizens2 JAR you downloaded (e.g. `2.0.22-SNAPSHOT`).
+The correct CITIZENS_VERSION to use can depend on your minecraft version. A list can be found here http://repo.citizensnpcs.co/net/citizensnpcs/citizensapi/ - or you can use the version listed in the Citizens2 JAR you downloaded (e.g. `2.0.24-SNAPSHOT`).
 
 Javadoc
 =======

--- a/README.md
+++ b/README.md
@@ -10,19 +10,20 @@ Maven
 Include CitizensAPI in your pom.xml like this (set the artifactId to citizens if you want to access the full plugin details of Citizens):
 ```
 <repository>
-            <id>everything</id>
-            <url>http://repo.citizensnpcs.co/</url>
+    <id>citizens-repo</id>
+    <url>http://repo.citizensnpcs.co/</url>
 </repository>
+```
+```
 <dependency>
-	<groupId>net.citizensnpcs</groupId>
-	<artifactId>citizensapi</artifactId>
-	<version>CITIZENS_VERSION</version>
-	<type>jar</type>
-	<scope>compile</scope>
+    <groupId>net.citizensnpcs</groupId>
+    <artifactId>citizensapi</artifactId>
+    <version>CITIZENS_VERSION</version>
+    <scope>scope</scope>
 </dependency>
 ```
 
-The correct CITIZENS_VERSION to use can depend on your minecraft version. A list can be found here http://repo.citizensnpcs.co/net/citizensnpcs/citizensapi/ - or you can use the version listed in the Citizens2 JAR you downloaded (e.g. `2.0.20-SNAPSHOT`).
+The correct CITIZENS_VERSION to use can depend on your minecraft version. A list can be found here http://repo.citizensnpcs.co/net/citizensnpcs/citizensapi/ - or you can use the version listed in the Citizens2 JAR you downloaded (e.g. `2.0.22-SNAPSHOT`).
 
 Javadoc
 =======


### PR DESCRIPTION
This fixes some issues with the maven information, namely the wrong dependency scope, the unnecessary type and the generic name of the repo. It also improves the formatting and ‒ as a small addition ‒ updates the example version to the latest one.