### PR TITLE
Make Javadoc link Spigot classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,10 +94,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
+                <version>3.0.1</version>
                 <configuration>
                     <author>false</author>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <doclint>none</doclint>
+                    <links>
+                      <link>https://hub.spigotmc.org/javadocs/spigot</link>
+                    </links>
                 </configuration>
             </plugin>
 		</plugins>


### PR DESCRIPTION
Before:
![Before](https://user-images.githubusercontent.com/10331806/52178516-ea0dd780-27cf-11e9-81da-3907d0406bb3.png)

After:
![After](https://user-images.githubusercontent.com/10331806/52178517-ea0dd780-27cf-11e9-9768-9e7b28e8185c.png)

In addition, I've updated the `javadoc` plugin.