### PR TITLE
Patch issues with inventory trait relating to "/npc inventory"

### DIFF
--- a/src/main/java/net/citizensnpcs/api/trait/trait/Inventory.java
+++ b/src/main/java/net/citizensnpcs/api/trait/trait/Inventory.java
@@ -42,7 +42,7 @@ public class Inventory extends Trait {
      * @return ItemStack array of an NPC's inventory contents
      */
     public ItemStack[] getContents() {
-        if (view != null) {
+        if (view != null && !views.isEmpty()) {
             return view.getContents();
         }
         return contents;
@@ -58,7 +58,7 @@ public class Inventory extends Trait {
             return;
         ItemStack[] contents = event.getInventory().getContents();
         for (int i = 0; i < contents.length; i++) {
-            this.contents[i] = contents[i]; 
+            this.contents[i] = contents[i];
             if (i == 0) {
                 npc.getTrait(Equipment.class).setItemInHand(contents[i]);
             }
@@ -148,14 +148,14 @@ public class Inventory extends Trait {
     }
 
     private void saveContents(Entity entity) {
-        if (entity instanceof Player) {
-            contents = ((Player) entity).getInventory().getContents();
-            npc.getTrait(Equipment.class).setItemInHand(contents[0]);
+        if (view != null && !views.isEmpty()) {
+            contents = view.getContents();
         }
-        if (view != null) {
-            for (int i = 0; i < view.getSize(); i++) {
-                view.setItem(i, contents[i]);
-            }
+        else if (entity instanceof InventoryHolder) {
+            contents = ((InventoryHolder) entity).getInventory().getContents();
+        }
+        if (entity instanceof Player) {
+            npc.getTrait(Equipment.class).setItemInHand(contents[0]);
         }
     }
 


### PR DESCRIPTION
Items disappeared when using "/npc inventory" - this commit fixes that.

Basically: in the `run()` method of the `Inventory` trait, contents were being copied over in the wrong direction - the inventory view (if opened by any player) is considered the primary inventory contents provider (and only if it's not open should the spawned entity's contents be allowed to take priority).

A more perfect solution might keep the two inventories (entity inventory, and `/npc inventory` command view inventory) 100% in sync, but that'd be a much more complicated task to achieve.|

Commit is tested and verified to completely solve the issue.