### PR TITLE
DoorExaminer now uses BlockData instead of BlockState

### DIFF
--- a/src/main/java/net/citizensnpcs/api/astar/pathfinder/DoorExaminer.java
+++ b/src/main/java/net/citizensnpcs/api/astar/pathfinder/DoorExaminer.java
@@ -7,11 +7,11 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
-import org.bukkit.material.Door;
 
 import net.citizensnpcs.api.astar.pathfinder.PathPoint.PathCallback;
 import net.citizensnpcs.api.event.NPCOpenDoorEvent;
 import net.citizensnpcs.api.npc.NPC;
+import org.bukkit.block.data.type.Door;
 
 public class DoorExaminer implements BlockExaminer {
     @Override
@@ -36,13 +36,17 @@ public class DoorExaminer implements BlockExaminer {
                 return;
             if (npc.getStoredLocation().distanceSquared(point.getLocation().add(0.5, 0, 0.5)) > 4)
                 return;
-            BlockState state = point.getState();
+            /*BlockState state = point.getState();
             Door door = (Door) state.getData();
             boolean bottom = !door.isTopHalf();
             Block set = bottom ? point : point.getRelative(BlockFace.DOWN);
             state = set.getState();
             door = (Door) state.getData();
             if (door.isOpen()) {
+                return;
+            }*/
+            Door door = (Door) point.getBlockData();
+            if(door.isOpen()) {
                 return;
             }
             NPCOpenDoorEvent event = new NPCOpenDoorEvent(npc, point);
@@ -51,8 +55,7 @@ public class DoorExaminer implements BlockExaminer {
                 return;
             }
             door.setOpen(true);
-            state.setData(door);
-            state.update();
+            point.setBlockData(door);
         }
     }
 }


### PR DESCRIPTION
I'm not sure if there's any special reason of why BlockState is used instead of BlockData. If there is one, just reject the pull request.
This is a fix for the issue in https://github.com/CitizensDev/Citizens2/issues/1897

I compiled CitizensAPI and Citizens2 in order to track down the NPCOpenDoorEvent and found that the code used in the DoorExaminer was using BlockState. When debugging it, it was returning wrong values, so I changed it to BlockData.

After recompiling with BlockData, the issue is fixed, as the NPCs use the door the way they're supposed to use it.