### PR TITLE
DoorExaminer now uses BlockData or BlockState depending on the version

### DIFF
--- a/src/main/java/net/citizensnpcs/api/astar/pathfinder/DoorExaminer.java
+++ b/src/main/java/net/citizensnpcs/api/astar/pathfinder/DoorExaminer.java
@@ -66,6 +66,7 @@ public class DoorExaminer implements BlockExaminer {
                     return;
                 }
                 door.setOpen(true);
+                state.setData(door);
                 state.update();
             }
         }

--- a/src/main/java/net/citizensnpcs/api/astar/pathfinder/DoorExaminer.java
+++ b/src/main/java/net/citizensnpcs/api/astar/pathfinder/DoorExaminer.java
@@ -2,6 +2,7 @@ package net.citizensnpcs.api.astar.pathfinder;
 
 import java.util.ListIterator;
 
+import net.citizensnpcs.api.util.SpigotUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -36,26 +37,37 @@ public class DoorExaminer implements BlockExaminer {
                 return;
             if (npc.getStoredLocation().distanceSquared(point.getLocation().add(0.5, 0, 0.5)) > 4)
                 return;
-            /*BlockState state = point.getState();
-            Door door = (Door) state.getData();
-            boolean bottom = !door.isTopHalf();
-            Block set = bottom ? point : point.getRelative(BlockFace.DOWN);
-            state = set.getState();
-            door = (Door) state.getData();
-            if (door.isOpen()) {
-                return;
-            }*/
-            Door door = (Door) point.getBlockData();
-            if(door.isOpen()) {
-                return;
+
+            if(SpigotUtil.isUsing1_13API()) {
+                Door door = (Door) point.getBlockData();
+                if(door.isOpen()) {
+                    return;
+                }
+                NPCOpenDoorEvent event = new NPCOpenDoorEvent(npc, point);
+                Bukkit.getPluginManager().callEvent(event);
+                if (event.isCancelled()) {
+                    return;
+                }
+                door.setOpen(true);
+                point.setBlockData(door);
+            } else {
+                BlockState state = point.getState();
+                org.bukkit.material.Door door = (org.bukkit.material.Door) state.getData();
+                boolean bottom = !door.isTopHalf();
+                Block set = bottom ? point : point.getRelative(BlockFace.DOWN);
+                state = set.getState();
+                door = (org.bukkit.material.Door) state.getData();
+                if (door.isOpen()) {
+                    return;
+                }
+                NPCOpenDoorEvent event = new NPCOpenDoorEvent(npc, point);
+                Bukkit.getPluginManager().callEvent(event);
+                if (event.isCancelled()) {
+                    return;
+                }
+                door.setOpen(true);
+                state.update();
             }
-            NPCOpenDoorEvent event = new NPCOpenDoorEvent(npc, point);
-            Bukkit.getPluginManager().callEvent(event);
-            if (event.isCancelled()) {
-                return;
-            }
-            door.setOpen(true);
-            point.setBlockData(door);
         }
     }
 }

--- a/src/main/java/net/citizensnpcs/api/astar/pathfinder/DoorExaminer.java
+++ b/src/main/java/net/citizensnpcs/api/astar/pathfinder/DoorExaminer.java
@@ -7,11 +7,11 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
-import org.bukkit.material.Door;
 
 import net.citizensnpcs.api.astar.pathfinder.PathPoint.PathCallback;
 import net.citizensnpcs.api.event.NPCOpenDoorEvent;
 import net.citizensnpcs.api.npc.NPC;
+import org.bukkit.block.data.type.Door;
 
 public class DoorExaminer implements BlockExaminer {
     @Override
@@ -36,13 +36,17 @@ public class DoorExaminer implements BlockExaminer {
                 return;
             if (npc.getStoredLocation().distanceSquared(point.getLocation().add(0.5, 0, 0.5)) > 4)
                 return;
-            BlockState state = point.getState();
+            /*BlockState state = point.getState();
             Door door = (Door) state.getData();
             boolean bottom = !door.isTopHalf();
             Block set = bottom ? point : point.getRelative(BlockFace.DOWN);
             state = set.getState();
             door = (Door) state.getData();
             if (door.isOpen()) {
+                return;
+            }*/
+            Door door = (Door) point.getBlockData();
+            if(door.isOpen()) {
                 return;
             }
             NPCOpenDoorEvent event = new NPCOpenDoorEvent(npc, point);
@@ -51,8 +55,7 @@ public class DoorExaminer implements BlockExaminer {
                 return;
             }
             door.setOpen(true);
-            state.setData(door);
-            state.update();
+            point.setBlockData(door);
         }
     }
 }


### PR DESCRIPTION
(Continuation of https://github.com/CitizensDev/CitizensAPI/pull/51)
I added the check to see if it's using 1.13+ or not. It uses BlockData if 1.13+ and the exact same previous code if not, so it should still work on previous versions.
I've only been able to test it on 1.13.2 and it works fine, so I hope that this works for every version.