### PR TITLE
Fixed javadoc warning

### DIFF
--- a/src/main/java/net/citizensnpcs/api/ai/PathStrategy.java
+++ b/src/main/java/net/citizensnpcs/api/ai/PathStrategy.java
@@ -6,7 +6,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.ai.event.CancelReason;
 
 /**
- * A pathfinding strategy directed at a target. Has two states: pathfinding -> cancelled represented by
+ * A pathfinding strategy directed at a target. Has two states: pathfinding -&gt; cancelled represented by
  * {@link #getCancelReason()}.
  */
 public interface PathStrategy {

--- a/src/main/java/net/citizensnpcs/api/ai/goals/WanderGoal.java
+++ b/src/main/java/net/citizensnpcs/api/ai/goals/WanderGoal.java
@@ -23,7 +23,7 @@ import net.citizensnpcs.api.astar.pathfinder.MinecraftBlockExaminer;
 import net.citizensnpcs.api.npc.NPC;
 
 /**
- * A sample {@link Goal}/{@link Behavior} that will wander within a certain radius or {@link QuadTree}.
+ * A sample {@link Goal}/{@link Behavior} that will wander within a certain radius or {@link PhTreeSolid}.
  */
 public class WanderGoal extends BehaviorGoalAdapter implements Listener {
     private int delay;

--- a/src/main/java/net/citizensnpcs/api/ai/tree/Behavior.java
+++ b/src/main/java/net/citizensnpcs/api/ai/tree/Behavior.java
@@ -10,7 +10,7 @@ import net.citizensnpcs.api.ai.Goal;
  * for AI that is easy for designers to use. It is a simple state machine using {@link BehaviorStatus} as the separate
  * states.
  *
- * This can be represented as shouldExecute() returning true -> RUNNING -> FAILURE | SUCCESS. The graph is made up of
+ * This can be represented as shouldExecute() returning true -&gt; RUNNING -&gt; FAILURE | SUCCESS. The graph is made up of
  * many {@link Selector}s and {@link Sequence}s, with the leaf nodes being concrete actions.
  *
  * @see <a href=

--- a/src/main/java/net/citizensnpcs/api/astar/AStarMachine.java
+++ b/src/main/java/net/citizensnpcs/api/astar/AStarMachine.java
@@ -27,9 +27,9 @@ public class AStarMachine<N extends AStarNode, P extends Plan> {
     }
 
     /**
-     * Creates an {@link AStarState} that can be reused across multiple invocations of {{@link #run(AStarState, int)}.
+     * Creates an {@link AStarState} that can be reused across multiple invocations of {@link #run(AStarMachine.AStarState, int)}.
      *
-     * @see #run(AStarState, int)
+     * @see #run(AStarMachine.AStarState, int)
      * @param goal
      *            The {@link AStarGoal} state
      * @param start
@@ -43,7 +43,7 @@ public class AStarMachine<N extends AStarNode, P extends Plan> {
     /**
      * Runs the {@link AStarState} until a plan is found.
      *
-     * @see #run(AStarState)
+     * @see #run(AStarMachine.AStarState)
      * @param state
      *            The state to use
      * @return The generated {@link Plan}, or <code>null</code>

--- a/src/main/java/net/citizensnpcs/api/command/CommandManager.java
+++ b/src/main/java/net/citizensnpcs/api/command/CommandManager.java
@@ -177,7 +177,7 @@ public class CommandManager implements TabCompleter {
      * A safe version of <code>execute</code> which catches and logs all errors that occur. Returns whether the command
      * handler should print usage or not.
      *
-     * @see #execute(Command, String[], CommandSender, Object...)
+     * @see #execute(org.bukkit.command.Command, String[], CommandSender, Object...)
      * @return Whether further usage should be printed
      */
     public boolean executeSafe(org.bukkit.command.Command command, String[] args, CommandSender sender,

--- a/src/main/java/net/citizensnpcs/api/npc/NPC.java
+++ b/src/main/java/net/citizensnpcs/api/npc/NPC.java
@@ -389,22 +389,22 @@ public interface NPC extends Agent, Cloneable {
      */
     public static final String PATHFINDER_OPEN_DOORS_METADATA = "pathfinder-open-doors";
     /**
-     * @see SkinTrait
+     * Take a look at the SkinTrait in the main module
      */
     @Deprecated
     public static final String PLAYER_SKIN_TEXTURE_PROPERTIES_METADATA = "player-skin-textures";
     /**
-     * @see SkinTrait
+     * Take a look at the SkinTrait in the main module
      */
     @Deprecated
     public static final String PLAYER_SKIN_TEXTURE_PROPERTIES_SIGN_METADATA = "player-skin-signature";
     /**
-     * @see SkinTrait
+     * Take a look at the SkinTrait in the main module
      */
     @Deprecated
     public static final String PLAYER_SKIN_USE_LATEST = "player-skin-use-latest-skin";
     /**
-     * @see SkinTrait
+     * Take a look at the SkinTrait in the main module
      */
     @Deprecated
     public static final String PLAYER_SKIN_UUID_METADATA = "player-skin-name";

--- a/src/main/java/net/citizensnpcs/api/persistence/Persist.java
+++ b/src/main/java/net/citizensnpcs/api/persistence/Persist.java
@@ -30,8 +30,8 @@ public @interface Persist {
      * The save key to use when saving. If not present, the field name will be used instead.
      *
      * <ul>
-     * <li><code>@Persist</code> -> root key + field name</li>
-     * <li><code>@Persist("")</code> -> root key + "" (or simply root key)</li>
+     * <li><code>@Persist</code> -&gt; root key + field name</li>
+     * <li><code>@Persist("")</code> -&gt; root key + "" (or simply root key)</li>
      * <li><code>@Persist("sub")</code> root key + "sub"</li>
      * </ul>
      */


### PR DESCRIPTION
There where a few warnings when creating the javadocs. Mainly because for the usage of the ">" sign. A few caused by missing imports.