### PR TITLE
Fix incorrect usage of findLastTag in keyExists

### DIFF
--- a/src/main/java/net/citizensnpcs/api/util/NBTStorage.java
+++ b/src/main/java/net/citizensnpcs/api/util/NBTStorage.java
@@ -319,7 +319,7 @@ public class NBTStorage implements FileStorage {
 
         @Override
         public boolean keyExists(String key) {
-            return findLastTag(createRelativeKey(key)) != null;
+            return findLastTag(createRelativeKey(key), false) != null;
         }
 
         @Override


### PR DESCRIPTION
``key`` is already relative so we shouldn't try to make it relative again because it causes things to break

https://github.com/CitizensDev/CitizensAPI/blob/a1a8d152671a8e34e8c0237fb0129d2d0f0d12bc/src/main/java/net/citizensnpcs/api/util/NBTStorage.java#L321-L323

https://github.com/CitizensDev/CitizensAPI/blob/a1a8d152671a8e34e8c0237fb0129d2d0f0d12bc/src/main/java/net/citizensnpcs/api/util/NBTStorage.java#L201-L203

https://github.com/CitizensDev/CitizensAPI/blob/a1a8d152671a8e34e8c0237fb0129d2d0f0d12bc/src/main/java/net/citizensnpcs/api/util/NBTStorage.java#L205-L207