### PR TITLE
Dont create stacktrace for CommandException

### DIFF
--- a/src/main/java/net/citizensnpcs/api/command/exception/CommandException.java
+++ b/src/main/java/net/citizensnpcs/api/command/exception/CommandException.java
@@ -18,5 +18,10 @@ public class CommandException extends Exception {
         super(t);
     }
 
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+
     private static final long serialVersionUID = 870638193072101739L;
 }


### PR DESCRIPTION
`CommandException`s are used for getting command state, which doesn't need to fill the stacktrace, disabling this is around 30~50x faster than original.