### PR TITLE
Add correct thread check on Folia and Bukkit

### DIFF
--- a/src/main/java/net/citizensnpcs/api/util/schedulers/SchedulerAdapter.java
+++ b/src/main/java/net/citizensnpcs/api/util/schedulers/SchedulerAdapter.java
@@ -134,8 +134,8 @@ public interface SchedulerAdapter {
 
     /**
      * Returns true if the current thread is the correct owner thread for safely accessing the target.
-     * <p>Spigot: true iff running on the main server thread.</p>
-     * <p>Folia: true iff the current thread owns the target's region (isOwnedByCurrentRegion).</p>
+     * <p>Spigot: true if running on the main server thread.</p>
+     * <p>Folia: true if the current thread owns the target's region (isOwnedByCurrentRegion).</p>
      *
      * @param entity the target entity
      * @return {@code true} if the current thread is the owner thread for the entity; {@code false} otherwise
@@ -143,9 +143,9 @@ public interface SchedulerAdapter {
     boolean isOnOwnerThread(Entity entity);
 
     /**
-     * Returns true if the current thread is the correct owner thread for safely accessing the region that owns the given location.
-     * <p>Spigot: mirrors {@code Bukkit.isPrimaryThread()}.</p>
-     * <p>Folia: mirrors {@code Bukkit.isOwnedByCurrentRegion(location)}.</p>
+     * Returns true if the current thread is the correct owner thread for safely accessing the target.
+     * <p>Spigot: true if running on the main server thread.</p>
+     * <p>Folia: true if the current thread owns the target's region (isOwnedByCurrentRegion).</p>
      *
      * @param location the target location
      * @return {@code true} if the current thread is the owner thread for the location; {@code false} otherwise
@@ -153,22 +153,21 @@ public interface SchedulerAdapter {
     boolean isOnOwnerThread(Location location);
 
     /**
-     * Returns true if the current thread is the correct owner thread for safely accessing the region that owns the given chunk.
-     * <p>Spigot: mirrors {@code Bukkit.isPrimaryThread()}.</p>
-     * <p>Folia: mirrors {@code Bukkit.isOwnedByCurrentRegion(world, chunkX, chunkZ)}.</p>
+     * Returns true if the current thread is the correct owner thread for safely accessing the target.
+     * <p>Spigot: true if running on the main server thread.</p>
+     * <p>Folia: true if the current thread owns the target's region (isOwnedByCurrentRegion).</p>
      *
-     * @param world  the world containing the target chunk
+     * @param world the target world
      * @param chunkX the target chunk X coordinate
      * @param chunkZ the target chunk Z coordinate
      * @return {@code true} if the current thread is the owner thread for the chunk; {@code false} otherwise
      */
-
     boolean isOnOwnerThread(World world, int chunkX, int chunkZ);
 
     /**
-     * Returns true if the current thread is the correct owner thread for safely accessing the region that owns the given block.
-     * <p>Spigot: mirrors {@code Bukkit.isPrimaryThread()}.</p>
-     * <p>Folia: mirrors {@code Bukkit.isOwnedByCurrentRegion(block)}.</p>
+     * Returns true if the current thread is the correct owner thread for safely accessing the target.
+     * <p>Spigot: true if running on the main server thread.</p>
+     * <p>Folia: true if the current thread owns the target's region (isOwnedByCurrentRegion).</p>
      *
      * @param block the target block
      * @return {@code true} if the current thread is the owner thread for the block; {@code false} otherwise

--- a/src/main/java/net/citizensnpcs/api/util/schedulers/SchedulerAdapter.java
+++ b/src/main/java/net/citizensnpcs/api/util/schedulers/SchedulerAdapter.java
@@ -2,6 +2,7 @@ package net.citizensnpcs.api.util.schedulers;
 
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 
 /**
@@ -130,4 +131,48 @@ public interface SchedulerAdapter {
      *            Period between each subsequent execution (in ticks).
      */
     SchedulerTask runTaskTimerAsynchronously(Runnable runnable, long delayTicks, long periodTicks);
+
+    /**
+     * Returns true if the current thread is the correct owner thread for safely accessing the target.
+     * <p>Spigot: true iff running on the main server thread.</p>
+     * <p>Folia: true iff the current thread owns the target's region (isOwnedByCurrentRegion).</p>
+     *
+     * @param entity the target entity
+     * @return {@code true} if the current thread is the owner thread for the entity; {@code false} otherwise
+     */
+    boolean isOnOwnerThread(Entity entity);
+
+    /**
+     * Returns true if the current thread is the correct owner thread for safely accessing the region that owns the given location.
+     * <p>Spigot: mirrors {@code Bukkit.isPrimaryThread()}.</p>
+     * <p>Folia: mirrors {@code Bukkit.isOwnedByCurrentRegion(location)}.</p>
+     *
+     * @param location the target location
+     * @return {@code true} if the current thread is the owner thread for the location; {@code false} otherwise
+     */
+    boolean isOnOwnerThread(Location location);
+
+    /**
+     * Returns true if the current thread is the correct owner thread for safely accessing the region that owns the given chunk.
+     * <p>Spigot: mirrors {@code Bukkit.isPrimaryThread()}.</p>
+     * <p>Folia: mirrors {@code Bukkit.isOwnedByCurrentRegion(world, chunkX, chunkZ)}.</p>
+     *
+     * @param world  the world containing the target chunk
+     * @param chunkX the target chunk X coordinate
+     * @param chunkZ the target chunk Z coordinate
+     * @return {@code true} if the current thread is the owner thread for the chunk; {@code false} otherwise
+     */
+
+    boolean isOnOwnerThread(World world, int chunkX, int chunkZ);
+
+    /**
+     * Returns true if the current thread is the correct owner thread for safely accessing the region that owns the given block.
+     * <p>Spigot: mirrors {@code Bukkit.isPrimaryThread()}.</p>
+     * <p>Folia: mirrors {@code Bukkit.isOwnedByCurrentRegion(block)}.</p>
+     *
+     * @param block the target block
+     * @return {@code true} if the current thread is the owner thread for the block; {@code false} otherwise
+     */
+    boolean isOnOwnerThread(Block block);
+
 }

--- a/src/main/java/net/citizensnpcs/api/util/schedulers/adapter/FoliaScheduler.java
+++ b/src/main/java/net/citizensnpcs/api/util/schedulers/adapter/FoliaScheduler.java
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.plugin.Plugin;
 
@@ -155,6 +156,26 @@ public class FoliaScheduler implements SchedulerAdapter {
         ScheduledTask task = asyncScheduler.runAtFixedRate(plugin, t -> runnable.run(),
                 ticksToMillis(Math.max(1, delayTicks)), ticksToMillis(Math.max(1, periodTicks)), TimeUnit.MILLISECONDS);
         return wrap(task);
+    }
+
+    @Override
+    public boolean isOnOwnerThread(Entity entity) {
+        return Bukkit.isOwnedByCurrentRegion(entity);
+    }
+
+    @Override
+    public boolean isOnOwnerThread(Location location) {
+        return Bukkit.isOwnedByCurrentRegion(location);
+    }
+
+    @Override
+    public boolean isOnOwnerThread(World world, int chunkX, int chunkZ) {
+        return Bukkit.isOwnedByCurrentRegion(world, chunkX, chunkZ);
+    }
+
+    @Override
+    public boolean isOnOwnerThread(Block block) {
+        return Bukkit.isOwnedByCurrentRegion(block);
     }
 
     private long ticksToMillis(long ticks) {

--- a/src/main/java/net/citizensnpcs/api/util/schedulers/adapter/SpigotScheduler.java
+++ b/src/main/java/net/citizensnpcs/api/util/schedulers/adapter/SpigotScheduler.java
@@ -3,6 +3,7 @@ package net.citizensnpcs.api.util.schedulers.adapter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
@@ -91,6 +92,26 @@ public class SpigotScheduler implements SchedulerAdapter {
     @Override
     public SchedulerTask runTaskTimerAsynchronously(Runnable runnable, long delayTicks, long periodTicks) {
         return wrap(Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, runnable, delayTicks, periodTicks));
+    }
+
+    @Override
+    public boolean isOnOwnerThread(Entity entity) {
+        return Bukkit.isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOnOwnerThread(Location location) {
+        return Bukkit.isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOnOwnerThread(World world, int chunkX, int chunkZ) {
+        return Bukkit.isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOnOwnerThread(Block block) {
+        return Bukkit.isPrimaryThread();
     }
 
     private SchedulerTask wrap(BukkitTask task) {


### PR DESCRIPTION
This is a follow-up to the porting process on Folia to verify that we are on the correct thread (regional/entity thread on Folia, and main thread on Spigot).