### PR TITLE
Fix for custom Paper builds

### DIFF
--- a/src/main/java/net/citizensnpcs/api/util/SpigotUtil.java
+++ b/src/main/java/net/citizensnpcs/api/util/SpigotUtil.java
@@ -206,7 +206,7 @@ public class SpigotUtil {
             if (parts[2].contains("-")) {
                 parts[2] = parts[2].split("-")[0];
             }
-            if (parts[2].contains("build")) {
+            if (parts[2].contains("build") || parts[2].contains("local")) {
                 parts[2] = "0";
             }
             if (parts.length >= 3) {


### PR DESCRIPTION
Custom Paper builds for 26.2 have the third entry as "local", which causes an error during the Integer parsing.

Reported at https://discord.com/channels/315163488085475337/1524905068535484437